### PR TITLE
Bump google-cloud-bigquery version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: 218546966473.dkr.ecr.us-east-1.amazonaws.com/circle-ci:tap-tester
+      - image: 218546966473.dkr.ecr.us-east-1.amazonaws.com/circle-ci:stitch-tap-tester
     steps:
       - checkout
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ jobs:
           command: |
             python3 -mvenv /usr/local/share/virtualenvs/tap-ga360
             source /usr/local/share/virtualenvs/tap-ga360/bin/activate
-            pip install -U 'pip<19.2' setuptools
+            pip install -U pip setuptools
             pip install .[dev]
       - run:
           name: 'pylint'

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
 .DEFAULT_GOAL := test
 
 test:
-	pylint tap_ga360 --disable missing-function-docstring,missing-class-docstring,missing-module-docstring,too-many-locals,invalid-name,line-too-long
+	pylint tap_ga360 --disable missing-function-docstring,missing-class-docstring,missing-module-docstring,too-many-locals,invalid-name,line-too-long,consider-using-f-string,unspecified-encoding

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ setup(
     url="https://singer.io",
     classifiers=["Programming Language :: Python :: 3 :: Only"],
     py_modules=["tap_ga360"],
-    install_requires=["google-cloud-bigquery==3.3.5", "singer-python==5.8"],
+    install_requires=["google-cloud-bigquery==3.3.5", "singer-python==5.12.2"],
     extras_require={
         'dev': [
             'pylint',

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ setup(
     url="https://singer.io",
     classifiers=["Programming Language :: Python :: 3 :: Only"],
     py_modules=["tap_ga360"],
-    install_requires=["google-cloud-bigquery==1.17.0", "singer-python==5.8"],
+    install_requires=["google-cloud-bigquery==3.3.5", "singer-python==5.8"],
     extras_require={
         'dev': [
             'pylint',


### PR DESCRIPTION
# Description of change
The version of google-cloud-bigquery required by the tap has an outdated protobuff package that causes errors during extraction

```
2022-10-21 19:01:59,908Z    tap -   File "/code/orchestrator/tap-env/lib/python3.9/site-packages/google/protobuf/descriptor.py", line 560, in __new__
2022-10-21 19:01:59,908Z    tap -     _message.Message._CheckCalledFromGeneratedFile()
2022-10-21 19:01:59,908Z    tap - TypeError: Descriptors cannot not be created directly.
```

Also bumps singer-python version for housekeeping.

# Manual QA steps
 - Ran discovery with a connection using most recent version of google-cloud-bigquery
 - PR-Alpha released and validated effective for affected connection
 
# Risks
 - The tap lacks a test-suite, so this change has not been tested for regressions.
 
# Rollback steps
 - revert this branch
