### PR TITLE
Pin numpy version to avoid errors with 2.X

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,7 +16,7 @@ jobs:
           name: 'pylint'
           command: |
             source /usr/local/share/virtualenvs/tap-ga360/bin/activate
-            make test
+            pylint tap_ga360 --disable missing-function-docstring,missing-class-docstring,missing-module-docstring,too-many-locals,invalid-name,line-too-long,consider-using-f-string,unspecified-encoding,use-yield-from
 
 workflows:
   version: 2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 0.2.1
+  * Pinnumpy version to avoid compatibility errors [#6](https://github.com/singer-io/tap-ga360/pull/6)
+
 ## 0.2.0
   * Update singer-python version and google-cloud-bigquery version [#3](https://github.com/singer-io/tap-ga360/pull/3)
 

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ setup(
     url="https://singer.io",
     classifiers=["Programming Language :: Python :: 3 :: Only"],
     py_modules=["tap_ga360"],
-    install_requires=["google-cloud-bigquery==3.3.5", "singer-python==5.12.2"],
+    install_requires=["google-cloud-bigquery==3.3.5", "singer-python==5.12.2", "numpy==1.26.4"],
     extras_require={
         'dev': [
             'pylint',

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup
 
 setup(
     name="tap-ga360",
-    version="0.2.0",
+    version="0.2.1",
     description="Singer.io tap for extracting data from Google Analytics 360 via BigQuery",
     author="Stitch",
     url="https://singer.io",


### PR DESCRIPTION
# Description of change
The latest numpy versions are not compatible with current dependencies, this pr pins numpy to an older version. 

Error without pinned version: 
> 24-12-04 18:59:49,587Z    tap - A module that was compiled using NumPy 1.x cannot be run in
2024-12-04 18:59:49,587Z    tap - NumPy 2.0.2 as it may crash. To support both 1.x and 2.x
2024-12-04 18:59:49,587Z    tap - versions of NumPy, modules must be compiled with NumPy 2.0.
2024-12-04 18:59:49,587Z    tap - Some module may need to rebuild instead e.g. with 'pybind11>=2.12'.
2024-12-04 18:59:49,587Z    tap -
2024-12-04 18:59:49,587Z    tap - If you are a user of the module, the easiest solution will be to
2024-12-04 18:59:49,587Z    tap - downgrade to 'numpy<2' or try to upgrade the affected module.
2024-12-04 18:59:49,587Z    tap - We expect that some modules will need time to support NumPy 2.

# Manual QA steps
 - Saw errors resolved by building docker container with pinned numpy 1.x version 
 
# Risks
 - low
 
# Rollback steps
 - revert this branch

#### AI generated code
https://internal.qlik.dev/general/ways-of-working/code-reviews/#guidelines-for-ai-generated-code
- [ ] this PR has been written with the help of GitHub Copilot or another generative AI tool
